### PR TITLE
Work page styling

### DIFF
--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -15,6 +15,7 @@ const StyledMain = styled.div`
     padding: 0;
 `
 
+
 const App = () => {
     const token = 
         document.querySelector('[name=csrf-token]').content

--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -10,7 +10,7 @@ import styled from 'styled-components'
 import Footer from './Footer';
 
 const StyledMain = styled.div`
-    background: #222;
+    background: #3a3a3a;
     margin: 0;
     padding: 0;
 `

--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -10,7 +10,7 @@ import styled from 'styled-components'
 import Footer from './Footer';
 
 const StyledMain = styled.div`
-    background: gray;
+    background: #222;
     margin: 0;
     padding: 0;
 `

--- a/app/javascript/components/Homepage/AnimationComponent.jsx
+++ b/app/javascript/components/Homepage/AnimationComponent.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import styled, { keyframes } from 'styled-components'
 
 const StyledSVG = styled.svg`
-    transform: scale(1.5) translate(-5%, 0%);
+    transform: scale(1.5) translate(-5%, 10%);
 
 
     body {

--- a/app/javascript/components/Homepage/AnimationComponent.jsx
+++ b/app/javascript/components/Homepage/AnimationComponent.jsx
@@ -6,7 +6,7 @@ const StyledSVG = styled.svg`
 
 
     body {
-    background: #111;
+    background: gray;
     }
 
     #circle-border {

--- a/app/javascript/components/Homepage/Homepage.jsx
+++ b/app/javascript/components/Homepage/Homepage.jsx
@@ -2,11 +2,12 @@ import React from 'react'
 import AnimationComponent from './AnimationComponent'
 import styled from 'styled-components'
 
+
 const StyledHomepage = styled.div`
     background: #484848;
     min-height: 90vh;
+    
 `
-
 
 const Homepage = () => {
     return (

--- a/app/javascript/components/Homepage/Homepage.jsx
+++ b/app/javascript/components/Homepage/Homepage.jsx
@@ -3,7 +3,7 @@ import AnimationComponent from './AnimationComponent'
 import styled from 'styled-components'
 
 const StyledHomepage = styled.div`
-    background: black;
+    background: #484848;
     min-height: 90vh;
 `
 

--- a/app/javascript/components/Homepage/Homepage.jsx
+++ b/app/javascript/components/Homepage/Homepage.jsx
@@ -4,7 +4,7 @@ import styled from 'styled-components'
 
 
 const StyledHomepage = styled.div`
-    background: #484848;
+    background: #3a3a3a;
     min-height: 90vh;
     
 `

--- a/app/javascript/components/NavBar/Nav.jsx
+++ b/app/javascript/components/NavBar/Nav.jsx
@@ -5,8 +5,8 @@ import StyledIcons from './StyledIcons'
 
 const StyledNav = styled.nav`
     font-family: 'Big Shoulders Display', light;
-    border-radius: 10px;
     height: 60px;
+    background: black;
 `
 
 const StyledList = styled.ul`

--- a/app/javascript/components/NavBar/Nav.jsx
+++ b/app/javascript/components/NavBar/Nav.jsx
@@ -7,6 +7,7 @@ const StyledNav = styled.nav`
     font-family: 'Big Shoulders Display', light;
     height: 60px;
     background: black;
+    padding-bottom: 10px;
 `
 
 const StyledList = styled.ul`

--- a/app/javascript/components/NavBar/Nav.jsx
+++ b/app/javascript/components/NavBar/Nav.jsx
@@ -7,7 +7,7 @@ const StyledNav = styled.nav`
     font-family: 'Big Shoulders Display', light;
     height: 60px;
     background: black;
-    padding-bottom: 10px;
+    padding: 10px 20px;
 `
 
 const StyledList = styled.ul`

--- a/app/javascript/components/NavBar/Nav.jsx
+++ b/app/javascript/components/NavBar/Nav.jsx
@@ -29,7 +29,7 @@ const StyledListItem = styled.li`
         margin-right: 25px;
     }
 
-    transition: background-color .4s;
+    transition: background-color;
     &:hover {
         background-color: turquoise;
     }
@@ -38,7 +38,7 @@ const StyledListItem = styled.li`
 const StyledLink = styled(Link)`
     color: #d8d8d8;
     text-decoration: none;
-    transition: color .4s;
+    transition: color;
 
     &:hover {
         color: black

--- a/app/javascript/components/NavBar/StyledIcons.jsx
+++ b/app/javascript/components/NavBar/StyledIcons.jsx
@@ -8,44 +8,32 @@ import styled from 'styled-components'
 const StyledIconWrapper = styled.div`
     display: inline-block;
     vertical-align: middle;
-    width: 30%;
+    width: auto;
     height: 100%;
     text-align: center;
 
     svg {
-        margin: 5px 20px;
+        margin: 5px 5px;
+        color: gray;
+        height: 35px;
+        width: 35px;
+        display: inline-block;
+        &:hover {
+            color: turquoise;
+        }
     }
-
 `
 
 const StyledGitHubIcon = styled(AiOutlineGithub)`
-    color: white;
-    height: 35px;
-    width: 35px;
-    display: inline-block;
-    &:hover {
-        color: turquoise;
-    }
+   
 `
 
 const StyledMailIcon = styled(HiOutlineMail)`
-    color: white;
-    height: 35px;
-    width: 35px;
-    display: inline-block;
-    &:hover {
-        color: turquoise;
-    }
+   
 `
 
 const StyledLinkedInIcon = styled(AiOutlineLinkedin)`
-    color: white;
-    height: 35px;
-    width: 35px;
-    display: inline-block;
-    &:hover {
-        color: turquoise;
-    }
+    
 `
 
 const StyledIcons = () => {

--- a/app/javascript/components/WorkPage/Tabs/TabsContainer.jsx
+++ b/app/javascript/components/WorkPage/Tabs/TabsContainer.jsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom'
 import CodeProjectModule from '../WorkModules/CodeProjectModule'
 import GraphicProjectModule from '../WorkModules/GraphicProjectModule'
 import styled from 'styled-components'
-import { HiArrowNarrowLeft } from 'react-icons/hi'
+import { FaArrowCircleLeft } from 'react-icons/fa'
 
 const StyledTabs = styled.button`
     font-family: 'Big Shoulders Display', light;
@@ -36,19 +36,27 @@ const StyledPageHeader = styled.h2`
     margin: 10px auto;
     text-align: center;
     font-size: 2.5em;
-    color: lightgray;
+    color: #e5e5e5;
 `
 
-const StyledArrowIcon = styled(HiArrowNarrowLeft)`
-    width: 40px;
-    height: 40px;
+const StyledArrowIcon = styled(FaArrowCircleLeft)`
+    width: 45px;
+    height: 45px;
     vertical-align: bottom;
-    color: turquoise;
+    color: #E1AD5B;
+    border: 1px black;
+
+    stroke: #CC851E;
+    stroke-dasharray: 3000;
+    stroke-dashoffset: 0;
+    stroke-width: 10px;
 
     transition: transform .6s;
     transform: ${props => 
         (props.activetab == 'tab-code-projects') ? 'rotateZ(0)' : 'rotateZ(180deg)'
     };
+    
+/
 
 `
 

--- a/app/javascript/components/WorkPage/Tabs/TabsContainer.jsx
+++ b/app/javascript/components/WorkPage/Tabs/TabsContainer.jsx
@@ -8,12 +8,12 @@ import { FaArrowCircleLeft } from 'react-icons/fa'
 const StyledTabs = styled.button`
     font-family: 'Big Shoulders Display', light;
     font-size: 2em;
-    color: #E1AD5B;
     background-color: #000000;
     border-radius: 5px;
     transition: color .6s;
     outline: none;
-
+    color: #E1AD5B;
+    
     &:hover {
         color: #e5e5e5;
     }
@@ -34,6 +34,20 @@ const StyledTabList = styled.ul`
 const StyledTabItem = styled.li`
     display: inline;
     margin: 0 25px;
+    transition: color .6s;
+    
+    #code-tab-button {
+        color: ${props => 
+            (props.activetab == 'tab-code-projects') ? 'turquoise' : '#E1AD5B'
+        };
+    }
+    
+    #graphic-tab-button {
+        color: ${props => 
+            (props.activetab == 'tab-graphic-projects') ? 'turquoise' : '#E1AD5B'
+        };
+    }
+
 `
 
 const StyledPageHeader = styled.h2`
@@ -47,7 +61,7 @@ const StyledArrowIcon = styled(FaArrowCircleLeft)`
     width: 45px;
     height: 45px;
     vertical-align: bottom;
-    color: #E1AD5B;
+    color: turquoise;
     border: 1px black;
 
     stroke: #CC851E;
@@ -59,9 +73,19 @@ const StyledArrowIcon = styled(FaArrowCircleLeft)`
     transform: ${props => 
         (props.activetab == 'tab-code-projects') ? 'rotateZ(0)' : 'rotateZ(180deg)'
     };
-    
-/
+`
 
+const StyledHeaderWrapper = styled.div`
+    background: url(https://media.istockphoto.com/vectors/seamless-wooden-pattern-wood-grain-texture-dense-lines-abstract-white-vector-id1202084477?b=1&k=6&m=1202084477&s=612x612&w=0&h=kJP6WEtSY1-mJkD7tFgX_A7NFX-EZv1hrjxLDpxFdjg=);
+    border-radius: 10px;
+    background-size: cover;
+`
+
+const FogEffectLayer = styled.div`
+    padding: 10px;
+    background: #120b018a;
+    border-radius: 10px;
+    backdrop-filter: invert(1) blur(2px);
 `
 
 const TabsContainer = () => {
@@ -69,24 +93,28 @@ const TabsContainer = () => {
 
     return (
         <div className='' id='tabs-container'>
-            <StyledPageHeader>My Personal Work</StyledPageHeader>
-            <StyledTabList>
-                <StyledTabItem className='tab' id='tab-code-projects'>
-                    <StyledTabs onClick={e => setActiveTab('tab-code-projects')}>Code Work</StyledTabs>
-                </StyledTabItem>
-                    <StyledArrowIcon
-                        activetab={activeTab}
-                    />
-                <StyledTabItem className='tab' id='tab-graphic-projects'>
-                    <StyledTabs onClick={e => setActiveTab('tab-graphic-projects')}>Graphic Design</StyledTabs>
-                </StyledTabItem>
-            </StyledTabList>
-                    <CodeProjectModule
-                        activeTab={activeTab}
-                    />
-                    <GraphicProjectModule
-                        activeTab={activeTab}
-                    />
+            <StyledHeaderWrapper>
+                <FogEffectLayer>
+                <StyledPageHeader>My Personal Work</StyledPageHeader>
+                <StyledTabList activeTab={activeTab}>
+                    <StyledTabItem activetab={activeTab} className='tab' id='tab-code-projects'>
+                        <StyledTabs id='code-tab-button' onClick={e => setActiveTab('tab-code-projects')}>Code Work</StyledTabs>
+                    </StyledTabItem>
+                        <StyledArrowIcon
+                            activetab={activeTab}
+                        />
+                    <StyledTabItem activetab={activeTab} className='tab' id='tab-graphic-projects'>
+                        <StyledTabs id='graphic-tab-button' onClick={e => setActiveTab('tab-graphic-projects')}>Graphic Design</StyledTabs>
+                    </StyledTabItem>
+                </StyledTabList>
+                </FogEffectLayer>
+            </StyledHeaderWrapper>
+            <CodeProjectModule
+                activeTab={activeTab}
+            />
+            <GraphicProjectModule
+                activeTab={activeTab}
+            />
         </div>
     )
 }

--- a/app/javascript/components/WorkPage/Tabs/TabsContainer.jsx
+++ b/app/javascript/components/WorkPage/Tabs/TabsContainer.jsx
@@ -8,15 +8,19 @@ import { FaArrowCircleLeft } from 'react-icons/fa'
 const StyledTabs = styled.button`
     font-family: 'Big Shoulders Display', light;
     font-size: 2em;
-    color: black;
-    button-style: none;
+    color: #E1AD5B;
+    background-color: #000000;
+    border-radius: 5px;
+    transition: color .6s;
+    outline: none;
 
     &:hover {
-        color: white;
+        color: #e5e5e5;
     }
 
     &:active {
         color: turquoise;
+        
     }
 `
 

--- a/app/javascript/components/WorkPage/Tabs/TabsContainer.jsx
+++ b/app/javascript/components/WorkPage/Tabs/TabsContainer.jsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import CodeProjectModule from '../WorkModules/CodeProjectModule'
 import GraphicProjectModule from '../WorkModules/GraphicProjectModule'
 import styled from 'styled-components'
+import { HiArrowNarrowLeft } from 'react-icons/hi'
 
 const StyledTabs = styled.button`
     font-family: 'Big Shoulders Display', light;
@@ -23,6 +24,7 @@ const StyledTabList = styled.ul`
     display: inline-block;
     text-align: center;
     width: 100%;
+    padding: 0;
 `
 
 const StyledTabItem = styled.li`
@@ -30,15 +32,39 @@ const StyledTabItem = styled.li`
     margin: 0 25px;
 `
 
+const StyledPageHeader = styled.h2`
+    margin: 10px auto;
+    text-align: center;
+    font-size: 2.5em;
+    color: lightgray;
+`
+
+const StyledArrowIcon = styled(HiArrowNarrowLeft)`
+    width: 40px;
+    height: 40px;
+    vertical-align: bottom;
+    color: turquoise;
+
+    transition: transform .6s;
+    transform: ${props => 
+        (props.activeTab == 'tab-code-projects') ? 'rotateZ(0)' : 'rotateZ(180deg)'
+    };
+
+`
+
 const TabsContainer = () => {
     const [ activeTab, setActiveTab ] = useState('tab-code-projects')
 
     return (
         <div className='' id='tabs-container'>
+            <StyledPageHeader>My Personal Work</StyledPageHeader>
             <StyledTabList>
                 <StyledTabItem className='tab' id='tab-code-projects'>
                     <StyledTabs onClick={e => setActiveTab('tab-code-projects')}>Code Work</StyledTabs>
                 </StyledTabItem>
+                    <StyledArrowIcon
+                        activeTab={activeTab}
+                    />
                 <StyledTabItem className='tab' id='tab-graphic-projects'>
                     <StyledTabs onClick={e => setActiveTab('tab-graphic-projects')}>Graphic Design</StyledTabs>
                 </StyledTabItem>

--- a/app/javascript/components/WorkPage/Tabs/TabsContainer.jsx
+++ b/app/javascript/components/WorkPage/Tabs/TabsContainer.jsx
@@ -47,7 +47,7 @@ const StyledArrowIcon = styled(HiArrowNarrowLeft)`
 
     transition: transform .6s;
     transform: ${props => 
-        (props.activeTab == 'tab-code-projects') ? 'rotateZ(0)' : 'rotateZ(180deg)'
+        (props.activetab == 'tab-code-projects') ? 'rotateZ(0)' : 'rotateZ(180deg)'
     };
 
 `
@@ -63,7 +63,7 @@ const TabsContainer = () => {
                     <StyledTabs onClick={e => setActiveTab('tab-code-projects')}>Code Work</StyledTabs>
                 </StyledTabItem>
                     <StyledArrowIcon
-                        activeTab={activeTab}
+                        activetab={activeTab}
                     />
                 <StyledTabItem className='tab' id='tab-graphic-projects'>
                     <StyledTabs onClick={e => setActiveTab('tab-graphic-projects')}>Graphic Design</StyledTabs>

--- a/app/javascript/components/WorkPage/Tabs/TabsContainer.jsx
+++ b/app/javascript/components/WorkPage/Tabs/TabsContainer.jsx
@@ -2,20 +2,47 @@ import React, { useState } from 'react'
 import { Link } from 'react-router-dom'
 import CodeProjectModule from '../WorkModules/CodeProjectModule'
 import GraphicProjectModule from '../WorkModules/GraphicProjectModule'
+import styled from 'styled-components'
+
+const StyledTabs = styled.button`
+    font-family: 'Big Shoulders Display', light;
+    font-size: 2em;
+    color: black;
+    button-style: none;
+
+    &:hover {
+        color: white;
+    }
+
+    &:active {
+        color: turquoise;
+    }
+`
+
+const StyledTabList = styled.ul`
+    display: inline-block;
+    text-align: center;
+    width: 100%;
+`
+
+const StyledTabItem = styled.li`
+    display: inline;
+    margin: 0 25px;
+`
 
 const TabsContainer = () => {
     const [ activeTab, setActiveTab ] = useState('tab-code-projects')
 
     return (
         <div className='' id='tabs-container'>
-            <ul>
-                <li className='tab' id='tab-code-projects'>
-                    <button onClick={e => setActiveTab('tab-code-projects')}>Code Work</button>
-                </li>
-                <li className='tab' id='tab-graphic-projects'>
-                    <button onClick={e => setActiveTab('tab-graphic-projects')}>Graphic Design</button>
-                </li>
-            </ul>
+            <StyledTabList>
+                <StyledTabItem className='tab' id='tab-code-projects'>
+                    <StyledTabs onClick={e => setActiveTab('tab-code-projects')}>Code Work</StyledTabs>
+                </StyledTabItem>
+                <StyledTabItem className='tab' id='tab-graphic-projects'>
+                    <StyledTabs onClick={e => setActiveTab('tab-graphic-projects')}>Graphic Design</StyledTabs>
+                </StyledTabItem>
+            </StyledTabList>
                     <CodeProjectModule
                         activeTab={activeTab}
                     />

--- a/app/javascript/components/WorkPage/WorkModules/CodeProjectModule.jsx
+++ b/app/javascript/components/WorkPage/WorkModules/CodeProjectModule.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import axios from 'axios'
 import styled from 'styled-components'
-import { SiHeroku } from 'react-icons/si'
+import { GrHeroku } from 'react-icons/gr'
 import { FaGithub } from 'react-icons/fa'
 import Carousel from 'react-elastic-carousel';
 
@@ -73,7 +73,7 @@ const StyledLinksWrapper = styled.div`
     font-size: 1.3em;
 `
 
-const StyledHerokuIcon = styled(SiHeroku)`
+const StyledHerokuIcon = styled(GrHeroku)`
     color: black;
     height: 40px;
     width: 40px;
@@ -121,7 +121,7 @@ const CodeProjectModule = ({ activeTab }) => {
                 <hr/>
                 <StyledLinksWrapper>
                     <a href={proj.github_url}>GitHub Repo <StyledGitIcon/></a>
-                    <a href={proj.deploy_url}>Deployment Link <StyledHerokuIcon/></a>
+                    <a href={proj.deploy_url}>Deployment Link<StyledHerokuIcon/></a>
                 </StyledLinksWrapper>
             </StyledProjGridModule>
         )

--- a/app/javascript/components/WorkPage/WorkModules/CodeProjectModule.jsx
+++ b/app/javascript/components/WorkPage/WorkModules/CodeProjectModule.jsx
@@ -7,7 +7,7 @@ import Carousel from 'react-elastic-carousel';
 
 const StyledProjGridContainer = styled.div`
     display: grid !important;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: 1fr;
     grid-gap: 30px;
     justify-content: space-around;
     padding: 25px;
@@ -25,7 +25,7 @@ const StyledProjGridModule = styled.div`
 const StyledProjHeading = styled.h3`
     margin: 5px;
     display: inline;
-    font-size: 1.9em;
+    font-size: 2em;
 `
 
 const StyledProjDescription = styled.p`
@@ -40,20 +40,20 @@ const StyledProjImage = styled.img`
     display: block;
     margin-left: auto;
     margin-right: auto;
-    width: 100%;
-    max-height: 500px;
+    width: auto;
+    max-height: 600px;
     border-radius: 5px;
 `
 
 const ImageWrapper = styled.div`
-    height: 500px;
+    height: auto;
     width: auto;
     padding-top: 30px;
     margin-bottom: 25px;
 `
 
 const StyledProjectContent = styled.div`
-    height: 200px;
+    height: auto;
     display: grid;
     grid-template-columns: 2fr 2fr;
 `
@@ -75,14 +75,14 @@ const StyledLinksWrapper = styled.div`
 
 const StyledHerokuIcon = styled(SiHeroku)`
     color: black;
-    height: 20px;
-    width: 20px;
+    height: 40px;
+    width: 40px;
 `
 
 const StyledGitIcon = styled(FaGithub)`
     color: black;
-    height: 30px;
-    width: 30px;
+    height: 40px;
+    width: 40px;
 `
 
 
@@ -107,14 +107,13 @@ const CodeProjectModule = ({ activeTab }) => {
                         <StyledProjHeading>{proj.title}</StyledProjHeading>
                     </div>
                     <StyledtechWrapper>
-                        <StyledProjTech>{proj.technology}</StyledProjTech>
+                        <StyledProjTech>Built with: {proj.technology}</StyledProjTech>
                     </StyledtechWrapper>
                     <StyledProjDescription>{proj.description}</StyledProjDescription>
                 </StyledProjectContent>
                 <ImageWrapper>
                     <Carousel
                         enableAutoPlay autoPlaySpeed={5500}
-                        showArrows={false}
                     >
                         {proj.images && proj.images.map(img => <StyledProjImage src={img.url}/>)}
                     </Carousel>

--- a/app/javascript/components/WorkPage/WorkModules/CodeProjectModule.jsx
+++ b/app/javascript/components/WorkPage/WorkModules/CodeProjectModule.jsx
@@ -12,13 +12,16 @@ const StyledProjGridContainer = styled.div`
     justify-content: space-around;
     padding: 25px;
 
-
+    hr {
+        border-color: gray;
+        margin-top: 0px;
+    }
 `
 
 const StyledProjGridModule = styled.div`
     display: inline-block;
     border-radius: 10px;
-    background: #888;
+    background: #35868C;
     padding: 15px;
 `
 
@@ -34,6 +37,7 @@ const StyledProjDescription = styled.p`
     font-size: 1.2em;
     grid-column: 1 / 3;
     overflow: scroll;
+    height: 150px;
 `
 
 const StyledProjImage = styled.img`
@@ -56,6 +60,9 @@ const StyledProjectContent = styled.div`
     height: auto;
     display: grid;
     grid-template-columns: 2fr 2fr;
+    background: #d2d2d266;
+    padding: 8px;
+    border-radius: 5px;
 `
 
 const StyledProjTech = styled.p`
@@ -70,19 +77,45 @@ const StyledtechWrapper = styled.div`
 const StyledLinksWrapper = styled.div`
     grid-column: 1 / 3;
     text-align: center;
-    font-size: 1.3em;
+    font-size: 1.8em;
+    a {
+        text-decoration: none;
+        color: #a9a9a9;
+        margin: 0 10px;
+
+        transition color .6s;
+
+        &:hover {
+            color: black;
+        }
+        &:hover svg {
+            color: black;
+        }
+    }
 `
 
 const StyledHerokuIcon = styled(GrHeroku)`
-    color: black;
+    color: #E1AD5B;
     height: 40px;
     width: 40px;
+    stroke: #CC851E;
+    stroke-dasharray: 3000;
+    stroke-dashoffset: 0;
+    stroke-width: 0.5px;
+    vertical-align: bottom;
+    transition color .6s;
 `
 
 const StyledGitIcon = styled(FaGithub)`
-    color: black;
+    color: #E1AD5B;
     height: 40px;
     width: 40px;
+    stroke: #CC851E;
+    stroke-dasharray: 3000;
+    stroke-dashoffset: 0;
+    stroke-width: 10px;
+    vertical-align: bottom;
+    transition color .6s;
 `
 
 
@@ -109,16 +142,16 @@ const CodeProjectModule = ({ activeTab }) => {
                     <StyledtechWrapper>
                         <StyledProjTech>Built with: {proj.technology}</StyledProjTech>
                     </StyledtechWrapper>
-                    <StyledProjDescription>{proj.description}</StyledProjDescription>
+                    <StyledProjDescription>
+                        <hr/>
+                        {proj.description}
+                    </StyledProjDescription>
                 </StyledProjectContent>
                 <ImageWrapper>
-                    <Carousel
-                        enableAutoPlay autoPlaySpeed={5500}
-                    >
+                    <Carousel>
                         {proj.images && proj.images.map(img => <StyledProjImage src={img.url}/>)}
                     </Carousel>
                 </ImageWrapper>
-                <hr/>
                 <StyledLinksWrapper>
                     <a href={proj.github_url}>GitHub Repo <StyledGitIcon/></a>
                     <a href={proj.deploy_url}>Deployment Link<StyledHerokuIcon/></a>

--- a/app/javascript/components/WorkPage/WorkModules/CodeProjectModule.jsx
+++ b/app/javascript/components/WorkPage/WorkModules/CodeProjectModule.jsx
@@ -3,6 +3,7 @@ import axios from 'axios'
 import styled from 'styled-components'
 import { SiHeroku } from 'react-icons/si'
 import { FaGithub } from 'react-icons/fa'
+import Carousel from 'react-elastic-carousel';
 
 const StyledProjGridContainer = styled.div`
     display: grid !important;
@@ -29,23 +30,36 @@ const StyledProjHeading = styled.h3`
 
 const StyledProjDescription = styled.p`
     margin: 5px;
-    font-size: 1em;
+    font-family: 'Roboto', sans-serif;
+    font-size: 1.2em;
     grid-column: 1 / 3;
+    overflow: scroll;
 `
 
 const StyledProjImage = styled.img`
-    height: 400px;
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    width: 100%;
+    max-height: 500px;
+    border-radius: 5px;
+`
+
+const ImageWrapper = styled.div`
+    height: 500px;
     width: auto;
+    padding-top: 30px;
+    margin-bottom: 25px;
 `
 
 const StyledProjectContent = styled.div`
-    height: 100px;
+    height: 200px;
     display: grid;
-    grid-template-columns: 2fr 1fr;
+    grid-template-columns: 2fr 2fr;
 `
 
 const StyledProjTech = styled.p`
-    font-size: 1.2em;
+    font-size: 1.7em;
     margin: 5px;
 `
 const StyledtechWrapper = styled.div`
@@ -56,6 +70,7 @@ const StyledtechWrapper = styled.div`
 const StyledLinksWrapper = styled.div`
     grid-column: 1 / 3;
     text-align: center;
+    font-size: 1.3em;
 `
 
 const StyledHerokuIcon = styled(SiHeroku)`
@@ -66,9 +81,10 @@ const StyledHerokuIcon = styled(SiHeroku)`
 
 const StyledGitIcon = styled(FaGithub)`
     color: black;
-    height: 20px;
-    width: 20px;
+    height: 30px;
+    width: 30px;
 `
+
 
 const CodeProjectModule = ({ activeTab }) => {
     const [codeProjects, setCodeProjects] = useState([]);
@@ -95,7 +111,14 @@ const CodeProjectModule = ({ activeTab }) => {
                     </StyledtechWrapper>
                     <StyledProjDescription>{proj.description}</StyledProjDescription>
                 </StyledProjectContent>
-                {proj.images && proj.images.map(img => <StyledProjImage src={img.url}/>)}
+                <ImageWrapper>
+                    <Carousel
+                        enableAutoPlay autoPlaySpeed={5500}
+                        showArrows={false}
+                    >
+                        {proj.images && proj.images.map(img => <StyledProjImage src={img.url}/>)}
+                    </Carousel>
+                </ImageWrapper>
                 <hr/>
                 <StyledLinksWrapper>
                     <a href={proj.github_url}>GitHub Repo <StyledGitIcon/></a>

--- a/app/javascript/components/WorkPage/WorkModules/CodeProjectModule.jsx
+++ b/app/javascript/components/WorkPage/WorkModules/CodeProjectModule.jsx
@@ -1,5 +1,74 @@
 import React, { useEffect, useState } from 'react'
 import axios from 'axios'
+import styled from 'styled-components'
+import { SiHeroku } from 'react-icons/si'
+import { FaGithub } from 'react-icons/fa'
+
+const StyledProjGridContainer = styled.div`
+    display: grid !important;
+    grid-template-columns: 1fr 1fr;
+    grid-gap: 30px;
+    justify-content: space-around;
+    padding: 25px;
+
+
+`
+
+const StyledProjGridModule = styled.div`
+    display: inline-block;
+    border-radius: 10px;
+    background: #888;
+    padding: 15px;
+`
+
+const StyledProjHeading = styled.h3`
+    margin: 5px;
+    display: inline;
+    font-size: 1.6em;
+`
+
+const StyledProjDescription = styled.p`
+    margin: 5px;
+    font-size: 1em;
+    grid-column: 1 / 3;
+`
+
+const StyledProjImage = styled.img`
+    height: 400px;
+    width: auto;
+`
+
+const StyledProjectContent = styled.div`
+    height: 100px;
+    display: grid;
+    grid-template-columns: 2fr 1fr;
+`
+
+const StyledProjTech = styled.p`
+    font-size: 1.2em;
+    margin: 5px;
+`
+const StyledtechWrapper = styled.div`
+    display: inline-block;
+    text-align: end;
+` 
+
+const StyledLinksWrapper = styled.div`
+    grid-column: 1 / 3;
+    text-align: center;
+`
+
+const StyledHerokuIcon = styled(SiHeroku)`
+    color: black;
+    height: 20px;
+    width: 20px;
+`
+
+const StyledGitIcon = styled(FaGithub)`
+    color: black;
+    height: 20px;
+    width: 20px;
+`
 
 const CodeProjectModule = ({ activeTab }) => {
     const [codeProjects, setCodeProjects] = useState([]);
@@ -16,21 +85,32 @@ const CodeProjectModule = ({ activeTab }) => {
     const codeProjectItems = codeProjects.map(item => {
         var proj = item.attributes
         return (
-            <div>
-                Title: {proj.title},
-                Desc: {proj.description} <br/>
-                Images: {proj.images && proj.images.map(img => <img src={img} height='150' width='150'/>)}
-            </div>
+            <StyledProjGridModule>
+                <StyledProjectContent>
+                    <div>
+                        <StyledProjHeading>{proj.title}</StyledProjHeading>
+                    </div>
+                    <StyledtechWrapper>
+                        <StyledProjTech>{proj.technology}</StyledProjTech>
+                    </StyledtechWrapper>
+                    <StyledProjDescription>{proj.description}</StyledProjDescription>
+                </StyledProjectContent>
+                {proj.images && proj.images.map(img => <StyledProjImage src={img.url}/>)}
+                <hr/>
+                <StyledLinksWrapper>
+                    <a href={proj.github_url}>GitHub Repo <StyledGitIcon/></a>
+                    <a href={proj.deploy_url}>Deployment Link <StyledHerokuIcon/></a>
+                </StyledLinksWrapper>
+            </StyledProjGridModule>
         )
     })
 
     return (
-        <div
+        <StyledProjGridContainer
             style={{display: (activeTab == 'tab-code-projects') ? 'block' : 'none'}}
         >
-            Code project module
             {codeProjectItems}
-        </div>
+        </StyledProjGridContainer>
     )
 }
 

--- a/app/javascript/components/WorkPage/WorkModules/CodeProjectModule.jsx
+++ b/app/javascript/components/WorkPage/WorkModules/CodeProjectModule.jsx
@@ -24,7 +24,7 @@ const StyledProjGridModule = styled.div`
 const StyledProjHeading = styled.h3`
     margin: 5px;
     display: inline;
-    font-size: 1.6em;
+    font-size: 1.9em;
 `
 
 const StyledProjDescription = styled.p`
@@ -106,11 +106,11 @@ const CodeProjectModule = ({ activeTab }) => {
     })
 
     return (
-        <StyledProjGridContainer
-            style={{display: (activeTab == 'tab-code-projects') ? 'block' : 'none'}}
-        >
-            {codeProjectItems}
-        </StyledProjGridContainer>
+        <div style={{display: (activeTab == 'tab-code-projects') ? 'block' : 'none'}}>
+            <StyledProjGridContainer>
+                {codeProjectItems}
+            </StyledProjGridContainer>
+        </div>
     )
 }
 

--- a/app/javascript/components/WorkPage/WorkModules/GraphicProjectModule.jsx
+++ b/app/javascript/components/WorkPage/WorkModules/GraphicProjectModule.jsx
@@ -1,5 +1,60 @@
 import React, { useState, useEffect } from 'react'
 import axios from 'axios'
+import Carousel from 'react-elastic-carousel';
+import styled from 'styled-components'
+
+const StyledProjGridContainer = styled.div`
+    display: grid !important;
+    grid-template-columns: 1fr;
+    grid-gap: 30px;
+    justify-content: space-around;
+    padding: 25px;
+
+
+`
+
+const StyledProjGridModule = styled.div`
+    display: inline-block;
+    border-radius: 10px;
+    background: #888;
+    padding: 15px;
+`
+
+const StyledProjHeading = styled.h3`
+    margin: 5px;
+    display: inline;
+    font-size: 2em;
+`
+
+const StyledProjDescription = styled.p`
+    margin: 5px;
+    font-family: 'Roboto', sans-serif;
+    font-size: 1.2em;
+    grid-column: 1 / 3;
+    overflow: scroll;
+`
+
+const StyledProjImage = styled.img`
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    width: auto;
+    max-height: 600px;
+    border-radius: 5px;
+`
+
+const ImageWrapper = styled.div`
+    height: auto;
+    width: auto;
+    padding-top: 30px;
+    margin-bottom: 25px;
+`
+
+const StyledProjectContent = styled.div`
+    height: auto;
+    display: grid;
+    grid-template-columns: 2fr 2fr;
+`
 
 const GraphicProjectModule = ({ activeTab }) => {
     const [graphicProjects, setGraphicProjects] = useState([]);
@@ -16,19 +71,32 @@ const GraphicProjectModule = ({ activeTab }) => {
     const graphicProjectItems = graphicProjects.map(item => {
         var proj = item.attributes
         return (
-            <div>
-                Title: {proj.title},
-                Desc: {proj.description} <br/>
-                Images: {proj.images && proj.images.map(img => <img src={img.url} height='150' width='150'/>)}
-            </div>
+            <StyledProjGridModule>
+                <StyledProjectContent>
+                    <div>
+                        <StyledProjHeading>{proj.title}</StyledProjHeading>
+                    </div>
+                    <StyledProjDescription>
+                        {proj.description}
+                    </StyledProjDescription>
+                </StyledProjectContent>
+                <ImageWrapper>
+                    <Carousel
+                        enableAutoPlay autoPlaySpeed={5500}
+                    >
+                        {proj.images && proj.images.map(img => <StyledProjImage src={img.url}/>)}
+                    </Carousel>
+                </ImageWrapper>
+            </StyledProjGridModule>
         )
     })
     return (
         <div
             style={{display: (activeTab == 'tab-graphic-projects') ? 'block' : 'none'}}
         >
-            Graphic Project Module
-            {graphicProjectItems}
+            <StyledProjGridContainer>
+                {graphicProjectItems}
+            </StyledProjGridContainer>
         </div>
     )
 }

--- a/app/javascript/components/WorkPage/WorkModules/GraphicProjectModule.jsx
+++ b/app/javascript/components/WorkPage/WorkModules/GraphicProjectModule.jsx
@@ -10,13 +10,16 @@ const StyledProjGridContainer = styled.div`
     justify-content: space-around;
     padding: 25px;
 
-
+    hr {
+        border-color: gray;
+        margin-top: 0px;
+    }
 `
 
 const StyledProjGridModule = styled.div`
     display: inline-block;
     border-radius: 10px;
-    background: #888;
+    background: #35868C;
     padding: 15px;
 `
 
@@ -32,6 +35,7 @@ const StyledProjDescription = styled.p`
     font-size: 1.2em;
     grid-column: 1 / 3;
     overflow: scroll;
+    height: 150px;
 `
 
 const StyledProjImage = styled.img`
@@ -54,6 +58,9 @@ const StyledProjectContent = styled.div`
     height: auto;
     display: grid;
     grid-template-columns: 2fr 2fr;
+    background: #d2d2d266;
+    padding: 8px;
+    border-radius: 5px;
 `
 
 const GraphicProjectModule = ({ activeTab }) => {
@@ -77,6 +84,7 @@ const GraphicProjectModule = ({ activeTab }) => {
                         <StyledProjHeading>{proj.title}</StyledProjHeading>
                     </div>
                     <StyledProjDescription>
+                        <hr/>
                         {proj.description}
                     </StyledProjDescription>
                 </StyledProjectContent>

--- a/app/javascript/components/WorkPage/WorkPage.jsx
+++ b/app/javascript/components/WorkPage/WorkPage.jsx
@@ -8,10 +8,13 @@ import styled from 'styled-components'
 const StyledWorkPage = styled.div`
     min-height: 100vh;
     overflow: scroll;
-    background: gray;
+    // background: gray;
+    background: rgb(56,163,165);
+    background: linear-gradient(0deg, rgba(56,163,165,1) 0%, rgba(20,20,20,1) 100%);
     max-width: 1400px;
     font-family: 'Big Shoulders Display', light;
     margin: 10px auto;
+    border-radius: 5px;
 `
 
 const WorkPage = () => {

--- a/app/javascript/components/WorkPage/WorkPage.jsx
+++ b/app/javascript/components/WorkPage/WorkPage.jsx
@@ -9,6 +9,8 @@ const StyledWorkPage = styled.div`
     min-height: 100vh;
     overflow: scroll;
     background: gray;
+    max-width: 1400px;
+    margin: 0 auto;
 `
 
 const WorkPage = () => {

--- a/app/javascript/components/WorkPage/WorkPage.jsx
+++ b/app/javascript/components/WorkPage/WorkPage.jsx
@@ -10,6 +10,7 @@ const StyledWorkPage = styled.div`
     overflow: scroll;
     background: gray;
     max-width: 1400px;
+    font-family: 'Big Shoulders Display', light;
     margin: 10px auto;
 `
 

--- a/app/javascript/components/WorkPage/WorkPage.jsx
+++ b/app/javascript/components/WorkPage/WorkPage.jsx
@@ -8,9 +8,7 @@ import styled from 'styled-components'
 const StyledWorkPage = styled.div`
     min-height: 100vh;
     overflow: scroll;
-    // background: gray;
-    background: rgb(56,163,165);
-    background: linear-gradient(0deg, rgba(56,163,165,1) 0%, rgba(20,20,20,1) 100%);
+    // background: #E1AD5B;
     max-width: 1400px;
     font-family: 'Big Shoulders Display', light;
     margin: 10px auto;

--- a/app/javascript/components/WorkPage/WorkPage.jsx
+++ b/app/javascript/components/WorkPage/WorkPage.jsx
@@ -10,7 +10,7 @@ const StyledWorkPage = styled.div`
     overflow: scroll;
     background: gray;
     max-width: 1400px;
-    margin: 0 auto;
+    margin: 10px auto;
 `
 
 const WorkPage = () => {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <link rel="preconnect" href="https://fonts.gstatic.com">
     <link href="https://fonts.googleapis.com/css2?family=Big+Shoulders+Display:wght@300;400;700&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400&display=swap" rel="stylesheet">
   </head>
   <body style='margin: 0px;'>
     <%= yield %>

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "prop-types": "^15.7.2",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
+    "react-elastic-carousel": "^0.11.1",
     "react-hook-form": "^6.14.0",
     "react-icons": "^4.2.0",
     "react-router-dom": "^5.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2098,6 +2098,11 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
+classnames@^2.2.6:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
+  integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
+
 clean-stack@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
@@ -6331,6 +6336,16 @@ react-dom@^17.0.1:
     object-assign "^4.1.1"
     scheduler "^0.20.1"
 
+react-elastic-carousel@^0.11.1:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/react-elastic-carousel/-/react-elastic-carousel-0.11.1.tgz#833b6ad921e5c76a250494519ad4f059c4e1f066"
+  integrity sha512-YfS6HA3dqVq3fHH2yy613XM2Ga0xEtHQ1MykEGSCRNk6wBRh80813HWE/sCo++zgEHz/NiOpNcLtpm3AUJImvw==
+  dependencies:
+    classnames "^2.2.6"
+    react-only-when "^1.0.2"
+    react-swipeable "^5.5.1"
+    resize-observer-polyfill "1.5.0"
+
 react-hook-form@^6.14.0:
   version "6.15.1"
   resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-6.15.1.tgz#57d887ec4dac5a6c0099902171aa39cc893f7bca"
@@ -6345,6 +6360,11 @@ react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-only-when@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/react-only-when/-/react-only-when-1.0.2.tgz#a8a79b48dd6cfbd91ddc710674a94153e88039d3"
+  integrity sha512-agE6l3L6bqaVuwNtjihTQ36M+VBfPS63KOzcNL4ZTmlwSxQPvhzIqmBWfiol0/wLYmKxCcBqgXkEJpvj5Kob8Q==
 
 react-router-dom@^5.2.0:
   version "5.2.0"
@@ -6374,6 +6394,13 @@ react-router@5.2.0:
     react-is "^16.6.0"
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
+
+react-swipeable@^5.5.1:
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/react-swipeable/-/react-swipeable-5.5.1.tgz#48ae6182deaf62f21d4b87469b60281dbd7c4a76"
+  integrity sha512-EQObuU3Qg3JdX3WxOn5reZvOSCpU4fwpUAs+NlXSN3y+qtsO2r8VGkVnOQzmByt3BSYj9EWYdUOUfi7vaMdZZw==
+  dependencies:
+    prop-types "^15.6.2"
 
 react@^17.0.1:
   version "17.0.1"
@@ -6579,6 +6606,11 @@ requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
+
+resize-observer-polyfill@1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.0.tgz#660ff1d9712a2382baa2cad450a4716209f9ca69"
+  integrity sha512-M2AelyJDVR/oLnToJLtuDJRBBWUGUvvGigj1411hXhAdyFWqMaqHp7TixW3FpiLuVaikIcR1QL+zqoJoZlOgpg==
 
 resolve-cwd@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
CSS styling changes
Styling changes for work pages for module like flow
Adds GoogleFonts to work page
Adds styling to tabs for work page
Adds ImageCarousel and Roboto font
Breaks up module grid
CSS change
Creates tab indicator arrow with animation
Creates background gradient
Fixes padding indent for ul in nav
Mimics styling into graphic groject modules
Adds animated styled arrow to indicate tab selection
Background color changes
Adds desc box height and adds breaks for visual digestion
Mimics CSS changes to grraphic modules
Styles Tab buttons for better visuals
Same backgrounds for each page
Re-positions main svg animation, tweaks tab button colors



* Notable LARGE AF pull request, in a professional setting I would split this up